### PR TITLE
Add option for IP address type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v0.1.9 (TBA)
 
 - `:httpd` server adapter now parses remote ip to tuple format
+- `:httpd` server adapter now parses host from host header
+- Specifying `:host` now also binds the hostname to IPv6 loopback
 - Added `:ipfamily` option to set IP address type to use
 
 ## v0.1.8 (2023-02-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.9 (TBA)
 
 - `:httpd` server adapter now parses remote ip to tuple format
+- Added `:ipfamily` option to set IP address type to use
 
 ## v0.1.8 (2023-02-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.9 (TBA)
+
+- `:httpd` server adapter now parses remote ip to tuple format
+
 ## v0.1.8 (2023-02-10)
 
 - Support Bandit and httpd web server

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ TestServer.start(http_server: {Bandit, []})
 
 You can create your own plug based HTTP Server Adapter by using the `TestServer.HTTPServer` behaviour.
 
+### IPv6
+
+Use the `:ipfamily` option to test with IPv6 when you are starting the test server:
+
+```elixir
+TestServer.start(ipfamily: :inet6)
+```
+
 <!-- MDOC !-->
 
 ## LICENSE

--- a/lib/test_server.ex
+++ b/lib/test_server.ex
@@ -160,7 +160,7 @@ defmodule TestServer do
   Produces a URL for current test server.
 
   ## Options
-    * `:host` - binary host value, it'll be added to inet for IP 127.0.0.1, defaults to `"localhost"`;
+    * `:host` - binary host value, it'll be added to inet for IP `127.0.0.1` and `::1`, defaults to `"localhost"`;
   """
   @spec url(binary(), keyword()) :: binary()
   def url(uri, opts) when is_binary(uri), do: url(fetch_instance!(), uri, opts)
@@ -237,6 +237,7 @@ defmodule TestServer do
   defp maybe_enable_host(host) do
     :inet_db.set_lookup([:file, :dns])
     :inet_db.add_host({127, 0, 0, 1}, [String.to_charlist(host)])
+    :inet_db.add_host({0, 0, 0, 0, 0, 0, 0, 1}, [String.to_charlist(host)])
 
     host
   end

--- a/lib/test_server.ex
+++ b/lib/test_server.ex
@@ -26,6 +26,8 @@ defmodule TestServer do
     * `:port`             - integer of port number, defaults to random port that can be opened;
     * `:scheme`           - an atom for the http scheme. Defaults to `:http`;
     * `:http_server`      - HTTP server configuration. Defaults to `{TestServer.HTTPServer.Httpd, []}`;
+    * `:tls`              - Passthru options for TLS configuration handled by the webserver;
+    * `:ipfamily`         - The IP address type to use, either `:inet` or `:inet6`. Defaults to `:inet`;
   """
   @spec start(keyword()) :: {:ok, pid()}
   def start(options \\ []) do

--- a/lib/test_server/http_server/bandit.ex
+++ b/lib/test_server/http_server/bandit.ex
@@ -8,12 +8,14 @@ defmodule TestServer.HTTPServer.Bandit do
   @behaviour WebSock
 
   @impl TestServer.HTTPServer
-  def start(instance, port, scheme, tls_options, bandit_options) do
+  def start(instance, port, scheme, options, bandit_options) do
+    opts = [options[:ipfamily]] ++ options[:tls]
+
     thousand_islands_options =
       bandit_options
       |> Keyword.get(:options, [])
       |> Keyword.put(:port, port)
-      |> Keyword.put(:transport_options, tls_options)
+      |> Keyword.update(:transport_options, opts, & &1 ++ opts)
 
     bandit_options =
       bandit_options

--- a/lib/test_server/http_server/httpd.ex
+++ b/lib/test_server/http_server/httpd.ex
@@ -5,7 +5,7 @@ defmodule TestServer.HTTPServer.Httpd do
   @behaviour TestServer.HTTPServer
 
   @impl TestServer.HTTPServer
-  def start(instance, port, scheme, tls_options, httpd_options) do
+  def start(instance, port, scheme, options, httpd_options) do
     httpd_options =
       httpd_options
       |> Keyword.put(:port, port)
@@ -14,7 +14,8 @@ defmodule TestServer.HTTPServer.Httpd do
       |> Keyword.put_new(:document_root, '/tmp')
       |> Keyword.put_new(:server_root, '/tmp')
       |> Keyword.put_new(:handler_plug, {TestServer.Plug, {__MODULE__, [], instance}})
-      |> put_tls_options(scheme, tls_options)
+      |> Keyword.put_new(:ipfamily, options[:ipfamily])
+      |> put_tls_options(scheme, options[:tls])
 
     case :inets.start(:httpd, httpd_options) do
       {:ok, pid} -> {:ok, pid, httpd_options}

--- a/lib/test_server/http_server/httpd.ex
+++ b/lib/test_server/http_server/httpd.ex
@@ -74,6 +74,7 @@ defmodule TestServer.HTTPServer.Httpd do
     {path, qs} = request_path(data)
     {port, host} = host(data)
     {_port, remote_ip} = peer(data)
+    {:ok, remote_ip} = :inet.parse_address(remote_ip)
 
     headers = Enum.map(parsed_header(data), &{to_string(elem(&1, 0)), to_string(elem(&1, 1))})
 
@@ -84,7 +85,7 @@ defmodule TestServer.HTTPServer.Httpd do
       owner: self(),
       path_info: split_path(to_string(path)),
       port: port,
-      remote_ip: to_string(remote_ip),
+      remote_ip: remote_ip,
       query_string: qs,
       req_headers: headers,
       request_path: path,

--- a/lib/test_server/http_server/httpd.ex
+++ b/lib/test_server/http_server/httpd.ex
@@ -108,9 +108,20 @@ defmodule TestServer.HTTPServer.Httpd do
   end
 
   defp host(data) do
-    {:init_data, _, host, _} = httpd(data, :init_data)
+    data
+    |> httpd(:parsed_header)
+    |> Enum.find(&elem(&1, 0) == 'host')
+    |> Kernel.||({'host', ''})
+    |> elem(1)
+    |> to_string()
+    |> :binary.split(":")
+    |> case do
+      [host, port] ->
+        {Integer.parse(port), host}
 
-    host
+      [host] ->
+        {nil, host}
+    end
   end
 
   defp peer(data) do

--- a/lib/test_server/http_server/plug_cowboy.ex
+++ b/lib/test_server/http_server/plug_cowboy.ex
@@ -16,14 +16,15 @@ defmodule TestServer.HTTPServer.Plug.Cowboy do
   ]
 
   @impl TestServer.HTTPServer
-  def start(instance, port, scheme, tls_options, cowboy_options) do
+  def start(instance, port, scheme, options, cowboy_options) do
     cowboy_options =
       cowboy_options
       |> Keyword.put_new(:protocol_options, @default_protocol_options)
       |> Keyword.put(:port, port)
       |> Keyword.put(:dispatch, dispatch(instance))
       |> Keyword.put(:ref, cowboy_ref(port))
-      |> Keyword.merge(tls_options)
+      |> Keyword.put(:net, options[:ipfamily])
+      |> Keyword.merge(options[:tls])
 
     case apply(Cowboy, scheme, [TestServer.Plug, {__MODULE__, %{}, instance}, cowboy_options]) do
       {:ok, pid} -> {:ok, pid, cowboy_options}


### PR DESCRIPTION
This PR makes it a lot more ergonomic to test IPv4 and IPv6 only networks.