### PR TITLE
Fixes compilation warning from Instance.handle_call/3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           otp-version: ${{matrix.version.otp}}
           elixir-version: ${{matrix.version.elixir}}
       - run: mix deps.get
+      - run: MIX_ENV=test mix compile --warnings-as-errors
       - run: HTTP_SERVER=${{matrix.http_server}} mix test
       - run: MIX_ENV=test mix credo
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog
+
+## v0.1.14 (TBA)
+
+- Fixed compiler warning in `TestServer.Instance`
+
+
 ## v0.1.13 (2023-08-26)
 
 - Fixed controlling process issues related to using the Bandit HTTP/2 adapter calling `Plug.Conn` functions in plug callbacks


### PR DESCRIPTION
Hey! 🖖 

This pull request:
- Groups `Instance.handle_call/3` together to fix the warning
- Adds a new CI step to verify for compilation warnings 

I caught the warning log when compiling a project that depends on `test_server`:

```elixir
==> test_server
Compiling 12 files (.ex)
     warning: clauses with the same name and arity (number of arguments) should be grouped together, "def handle_call/3" was previously defined (lib/test_server/instance.ex:184)
     │
 246 │   def handle_call(
     │       ~
     │
     └─ lib/test_server/instance.ex:246:7
```

