### PR TITLE
Limit number of acceptors with Bandit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.18 (TBA)
+
+- Limit number of Bandit acceptors to 1 to improve performance
+
 ## v0.1.17 (2023-09-30)
 
 - Fixed invalid spec for `TestServer.url/1`

--- a/lib/test_server/http_server/bandit.ex
+++ b/lib/test_server/http_server/bandit.ex
@@ -23,6 +23,9 @@ if Code.ensure_loaded?(Bandit) do
       thousand_islands_options =
         bandit_options
         |> Keyword.get(:thousand_island_options, [])
+        # For tests it is not necessary to open the default 100 acceptor
+        # processes
+        |> Keyword.put(:num_acceptors, 1)
         |> Keyword.put(:port, port)
         |> Keyword.put(:transport_options, ipfamily_opts ++ transport_options)
 


### PR DESCRIPTION
There's no need to have the default 100 acceptors, we only need one for tests.