### PR TITLE
Allow `:to` option for `TestServer.websocket_init/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.19 (TBA)
+
+- Allow `:to` plug to be set for `TestServer.websocket_init/3` for handshake
+
 ## v0.1.18 (2024-12-29)
 
 - Limit number of Bandit acceptors to 1 to improve performance

--- a/lib/test_server/plug.ex
+++ b/lib/test_server/plug.ex
@@ -8,7 +8,7 @@ defmodule TestServer.Plug do
 
   def call(conn, {http_server, args, instance}) do
     case Instance.dispatch(instance, {:plug, conn}) do
-      {:ok, %{private: %{websocket: {socket, state}}} = conn} ->
+      {:ok, %{state: :unset, private: %{websocket: {socket, state}}} = conn} ->
         :ok = Instance.put_websocket_connection(socket, http_server.get_socket_pid(conn))
         Plug.Conn.upgrade_adapter(conn, :websocket, {http_server, {socket, state}, args})
 


### PR DESCRIPTION
Addresses the issue in #31 of not being able to assert on the handshake.

The assertion can now be done with:

```elixir
assert {:ok, _socket} =
          TestServer.websocket_init("/ws",
            to: fn conn ->
              assert Plug.Conn.get_req_header(conn, "upgrade") == ["websocket"]

              conn
            end
          )

assert {:ok, _client} = WebSocketClient.start_link(TestServer.url("/ws"))
```