### PR TITLE
Ensure that inets is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.20 (TBA)
+
+- Include `:inets` in `:extra_applications` to prevent compilation issue with `TestServer.HTTPServer.Httpd`
+
 ## v0.1.19 (2025-02-27)
 
 - Allow `:to` plug to be set for `TestServer.websocket_init/3` for handshake

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule TestServer.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :crypto, :public_key],
+      extra_applications: [:logger, :crypto, :public_key, :inets],
       mod: {TestServer.Application, []}
     ]
   end


### PR DESCRIPTION
Resolves https://github.com/danschultzer/test_server/discussions/36.

I've somehow always tested in environments where `:inets` was included by some dependency that compiled before TestServer.