### PR TITLE
Set num_acceptors transport options for cowboy plug to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Requires Elixir 1.14 or higher.
 
 - Fixed incorrect formatting of websocket handlers
 - Fixed breaking change with plug 1.19
+- Limit number of Cowboy acceptors to 1 to improve performance
 
 ## v0.1.21 (2025-06-20)
 

--- a/lib/test_server/http_server/plug_cowboy.ex
+++ b/lib/test_server/http_server/plug_cowboy.ex
@@ -3,8 +3,9 @@ if Code.ensure_loaded?(Plug.Cowboy) do
     @moduledoc """
     HTTP server adapter using `Plug.Cowboy`.
 
-    This adapter will be used by default if `Bandit` is not loaded and
-    `Plug.Cowboy` is loaded in the project.
+    By default only one acceptor process is started which is enough for
+    testing.  This adapter will be used by default if `Bandit` is not loaded
+    and `Plug.Cowboy` is loaded in the project.
 
     ## Usage
 
@@ -26,10 +27,6 @@ if Code.ensure_loaded?(Plug.Cowboy) do
       request_timeout: :timer.seconds(1)
     ]
 
-    @default_transport_options [
-      num_acceptors: 1
-    ]
-
     @impl TestServer.HTTPServer
     def start(instance, port, scheme, options, cowboy_options) do
       cowboy_options =
@@ -37,7 +34,7 @@ if Code.ensure_loaded?(Plug.Cowboy) do
         |> Keyword.put_new(:protocol_options, @default_protocol_options)
         # For tests it is not necessary to open the default 100 acceptor
         # processes
-        |> Keyword.put_new(:transport_options, @default_transport_options)
+        |> Keyword.put_new(:transport_options, num_acceptors: 1)
         |> Keyword.put(:port, port)
         |> Keyword.put(:dispatch, dispatch(instance))
         |> Keyword.put(:ref, cowboy_ref(port))


### PR DESCRIPTION
Hello, I propose to set `num_acceptors` for transport options to cowboy plug be default to 1 as it's done for bandit. Same motivation here – for tests we don't need a large amount of processes to be ready to accept a connection. 