### PR TITLE
Add TestServer.SSH — mock SSH server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Features:
 - HTTP/1
 - HTTP/2
 - WebSocket
+- SSH (exec and shell)
 - Built-in TLS with self-signed certificates
 - Plug route matching
 
 ## Protocols
 
 - `TestServer.HTTP` - HTTP/1, HTTP/2, and WebSocket.
+- `TestServer.SSH` - SSH exec and interactive shell.
 
 <!-- MDOC !-->
 

--- a/lib/test_server/ssh.ex
+++ b/lib/test_server/ssh.ex
@@ -1,0 +1,86 @@
+defmodule TestServer.SSH do
+  @external_resource "lib/test_server/ssh/README.md"
+  @moduledoc "lib/test_server/ssh/README.md"
+             |> File.read!()
+             |> String.split("<!-- MDOC !-->")
+             |> Enum.fetch!(1)
+
+  alias TestServer.SSH
+
+  @spec start(keyword()) :: {:ok, pid()}
+  def start(options \\ []) do
+    TestServer.start_instance(__MODULE__, options, &verify_instance!/1)
+  end
+
+  defp verify_instance!(instance) do
+    verify_handlers!(:exec, instance)
+    verify_handlers!(:shell, instance)
+  end
+
+  defp verify_handlers!(type, instance) do
+    instance
+    |> SSH.Instance.handlers(type)
+    |> Enum.reject(& &1.suspended)
+    |> case do
+      [] ->
+        :ok
+
+      active ->
+        raise """
+        #{TestServer.format_instance(__MODULE__, instance)} did not receive #{type} requests for these handlers before the test ended:
+
+        #{SSH.Instance.format_handlers(active)}
+        """
+    end
+  end
+
+  @spec stop() :: :ok | {:error, term()}
+  def stop, do: stop(TestServer.fetch_instance!(__MODULE__))
+
+  @spec stop(pid()) :: :ok | {:error, term()}
+  def stop(instance), do: TestServer.stop_instance(__MODULE__, instance)
+
+  @spec address() :: {binary(), :inet.port_number()}
+  def address, do: address(TestServer.fetch_instance!(__MODULE__))
+
+  @spec address(pid()) :: {binary(), :inet.port_number()}
+  def address(instance) do
+    TestServer.ensure_instance_alive!(__MODULE__, instance)
+    options = SSH.Instance.get_options(instance)
+    {"localhost", Keyword.fetch!(options, :port)}
+  end
+
+  @spec exec(keyword()) :: :ok
+  def exec(options) when is_list(options) do
+    {:ok, instance} = TestServer.autostart_instance(__MODULE__)
+    exec(instance, options)
+  end
+
+  @spec exec(pid(), keyword()) :: :ok
+  def exec(instance, options) when is_pid(instance) and is_list(options) do
+    TestServer.ensure_instance_alive!(__MODULE__, instance)
+    [_first_module_entry | stacktrace] = TestServer.get_pruned_stacktrace(__MODULE__)
+    options = Keyword.put_new(options, :to, &default_exec_handler/2)
+    {:ok, _handler} = SSH.Instance.register(instance, {:exec, options, stacktrace})
+    :ok
+  end
+
+  defp default_exec_handler(_cmd, state), do: {:reply, {0, "", ""}, state}
+
+  @spec shell(keyword()) :: :ok
+  def shell(options) when is_list(options) do
+    {:ok, instance} = TestServer.autostart_instance(__MODULE__)
+    shell(instance, options)
+  end
+
+  @spec shell(pid(), keyword()) :: :ok
+  def shell(instance, options) when is_pid(instance) and is_list(options) do
+    TestServer.ensure_instance_alive!(__MODULE__, instance)
+    [_first_module_entry | stacktrace] = TestServer.get_pruned_stacktrace(__MODULE__)
+    options = Keyword.put_new(options, :to, &default_shell_handler/2)
+    {:ok, _handler} = SSH.Instance.register(instance, {:shell, options, stacktrace})
+    :ok
+  end
+
+  defp default_shell_handler(data, state), do: {:reply, data, state}
+end

--- a/lib/test_server/ssh/README.md
+++ b/lib/test_server/ssh/README.md
@@ -1,0 +1,90 @@
+# SSH
+
+<!-- MDOC !-->
+
+Mock SSH servers with exec and shell handler expectations, password and public key authentication.
+
+### Exec
+
+Add exec handler expectations with `TestServer.SSH.exec/1`. By default the handler returns exit code 0 with empty stdout and stderr.
+
+```elixir
+test "runs a remote command" do
+  # The test server will autostart if not already running
+  TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {0, "deployed v1.0\n", ""}, state} end)
+
+  {host, port} = TestServer.SSH.address()
+  assert {:ok, 0, "deployed v1.0\n", ""} = MyApp.SSH.run(host, port, "deploy")
+end
+```
+
+The `:to` handler receives `{command, state}` and must return `{:reply, {exit_code, stdout, stderr}, state}`:
+
+```elixir
+TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {1, "", "permission denied\n"}, state} end)
+```
+
+A `:match` function can be set to conditionally dispatch to a handler:
+
+```elixir
+TestServer.SSH.exec(match: fn cmd, _state -> cmd == "deploy" end, to: &deploy_handler/2)
+TestServer.SSH.exec(match: fn cmd, _state -> cmd == "status" end, to: &status_handler/2)
+```
+
+When a handler is matched it is consumed. Handlers are dispatched in the order they were added (FIFO):
+
+```elixir
+TestServer.SSH.exec(to: fn _, state -> {:reply, {0, "deploy 1\n", ""}, state} end)
+TestServer.SSH.exec(to: fn _, state -> {:reply, {0, "deploy 2\n", ""}, state} end)
+
+assert {:ok, 0, "deploy 1\n", ""} = MyApp.SSH.run(host, port, "deploy")
+assert {:ok, 0, "deploy 2\n", ""} = MyApp.SSH.run(host, port, "deploy")
+```
+
+### Shell
+
+Add shell handler expectations with `TestServer.SSH.shell/1`. By default the handler echoes received data.
+
+```elixir
+test "interactive shell session" do
+  TestServer.SSH.shell(to: fn data, state -> {:reply, "echo: " <> data, state} end)
+
+  {host, port} = TestServer.SSH.address()
+  {:ok, response} = MyApp.SSH.shell(host, port, "hello\n")
+  assert response == "echo: hello\n"
+end
+```
+
+### Authentication
+
+#### Password
+
+Pass a list of `{username, password}` tuples as `:credentials`:
+
+```elixir
+{:ok, instance} = TestServer.SSH.start(credentials: [{"deploy", "hunter2"}])
+TestServer.SSH.exec(instance, to: fn _, state -> {:reply, {0, "ok\n", ""}, state} end)
+
+{host, port} = TestServer.SSH.address(instance)
+assert {:ok, 0, "ok\n", ""} = MyApp.SSH.run(host, port, "deploy", user: "deploy", password: "hunter2")
+```
+
+#### Public Key
+
+Pass a `{username, :public_key, pem_binary}` tuple in `:credentials`:
+
+```elixir
+pem = File.read!("test/fixtures/id_rsa.pem")
+{:ok, instance} = TestServer.SSH.start(credentials: [{"deploy", :public_key, pem}])
+```
+
+#### No Authentication
+
+Omit the `:credentials` option entirely to accept any connection without authentication:
+
+```elixir
+{:ok, _instance} = TestServer.SSH.start()
+# All clients are accepted regardless of credentials
+```
+
+<!-- MDOC !-->

--- a/lib/test_server/ssh/channel.ex
+++ b/lib/test_server/ssh/channel.ex
@@ -1,0 +1,120 @@
+defmodule TestServer.SSH.Channel do
+  @moduledoc false
+
+  @behaviour :ssh_server_channel
+
+  alias TestServer.SSH.Instance
+
+  defstruct [:instance, :channel_id, :connection, type: nil, handler_state: %{}]
+
+  @impl true
+  def init(instance: instance) do
+    {:ok, %__MODULE__{instance: instance}}
+  end
+
+  @impl true
+  def handle_msg({:ssh_channel_up, channel_id, connection}, state) do
+    {:ok, %{state | channel_id: channel_id, connection: connection}}
+  end
+
+  def handle_msg(_msg, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_ssh_msg({:ssh_cm, conn, {:exec, ch_id, want_reply, command}}, state) do
+    command = to_string(command)
+    :ssh_connection.reply_request(conn, want_reply, :success, ch_id)
+
+    case GenServer.call(state.instance, {:dispatch, {:exec, command, state.handler_state}}) do
+      {:ok, {:reply, {exit_code, stdout, stderr}, new_handler_state}} ->
+        unless IO.iodata_length(stdout) == 0,
+          do: :ssh_connection.send(conn, ch_id, stdout)
+
+        unless IO.iodata_length(stderr) == 0,
+          do: :ssh_connection.send(conn, ch_id, 1, stderr)
+
+        :ssh_connection.exit_status(conn, ch_id, exit_code)
+        :ssh_connection.send_eof(conn, ch_id)
+        :ssh_connection.close(conn, ch_id)
+        {:stop, ch_id, %{state | handler_state: new_handler_state}}
+
+      {:ok, {:ok, new_handler_state}} ->
+        :ssh_connection.exit_status(conn, ch_id, 0)
+        :ssh_connection.send_eof(conn, ch_id)
+        :ssh_connection.close(conn, ch_id)
+        {:stop, ch_id, %{state | handler_state: new_handler_state}}
+
+      {:error, :not_found} ->
+        message =
+          "#{TestServer.format_instance(TestServer.SSH, state.instance)} received an unexpected SSH exec request: #{inspect(command)}"
+
+        report_error_and_close_exec(conn, ch_id, state, RuntimeError.exception(message), [])
+
+      {:error, {exception, stacktrace}} ->
+        report_error_and_close_exec(conn, ch_id, state, exception, stacktrace)
+    end
+  end
+
+  def handle_ssh_msg({:ssh_cm, conn, {:shell, ch_id, want_reply}}, state) do
+    :ssh_connection.reply_request(conn, want_reply, :success, ch_id)
+    {:ok, %{state | type: :shell, channel_id: ch_id, connection: conn}}
+  end
+
+  def handle_ssh_msg({:ssh_cm, conn, {:data, ch_id, 0, data}}, %{type: :shell} = state) do
+    :ssh_connection.adjust_window(conn, ch_id, byte_size(data))
+
+    case GenServer.call(state.instance, {:dispatch, {:shell, data, state.handler_state}}) do
+      {:ok, {:reply, output, new_handler_state}} ->
+        :ssh_connection.send(conn, ch_id, output)
+        {:ok, %{state | handler_state: new_handler_state}}
+
+      {:ok, {:ok, new_handler_state}} ->
+        {:ok, %{state | handler_state: new_handler_state}}
+
+      {:error, :not_found} ->
+        message =
+          "#{TestServer.format_instance(TestServer.SSH, state.instance)} received unexpected SSH shell data: #{inspect(data)}"
+
+        Instance.report_error(state.instance, {RuntimeError.exception(message), []})
+        {:ok, state}
+
+      {:error, {exception, stacktrace}} ->
+        Instance.report_error(state.instance, {exception, stacktrace})
+        {:ok, state}
+    end
+  end
+
+  def handle_ssh_msg({:ssh_cm, conn, {:pty, ch_id, want_reply, _pty_info}}, state) do
+    :ssh_connection.reply_request(conn, want_reply, :success, ch_id)
+    {:ok, state}
+  end
+
+  def handle_ssh_msg({:ssh_cm, conn, {:env, ch_id, want_reply, _name, _value}}, state) do
+    :ssh_connection.reply_request(conn, want_reply, :success, ch_id)
+    {:ok, state}
+  end
+
+  def handle_ssh_msg({:ssh_cm, _conn, {:eof, _ch_id}}, state) do
+    {:ok, state}
+  end
+
+  def handle_ssh_msg({:ssh_cm, _conn, {:closed, ch_id}}, state) do
+    {:stop, ch_id, state}
+  end
+
+  def handle_ssh_msg(_msg, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def terminate(_reason, _state), do: :ok
+
+  defp report_error_and_close_exec(conn, ch_id, state, exception, stacktrace) do
+    Instance.report_error(state.instance, {exception, stacktrace})
+    :ssh_connection.exit_status(conn, ch_id, 1)
+    :ssh_connection.send_eof(conn, ch_id)
+    :ssh_connection.close(conn, ch_id)
+    {:stop, ch_id, state}
+  end
+end

--- a/lib/test_server/ssh/instance.ex
+++ b/lib/test_server/ssh/instance.ex
@@ -1,0 +1,221 @@
+defmodule TestServer.SSH.Instance do
+  @moduledoc false
+
+  use GenServer
+
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options)
+  end
+
+  def register(instance, {type, options, stacktrace}) when type in [:exec, :shell] do
+    options[:match] && ensure_function!(options[:match], 2)
+    ensure_function!(Keyword.fetch!(options, :to), 2)
+    GenServer.call(instance, {:register, {type, options, stacktrace}})
+  end
+
+  defp ensure_function!(fun, arity) when is_function(fun, arity), do: :ok
+  defp ensure_function!(fun, _arity), do: raise(BadFunctionError, term: fun)
+
+  def get_options(instance) do
+    GenServer.call(instance, :options)
+  end
+
+  def handlers(instance, type) when type in [:exec, :shell] do
+    GenServer.call(instance, {:handlers, type})
+  end
+
+  def format_handlers(handlers) do
+    handlers
+    |> Enum.with_index()
+    |> Enum.map_join("\n\n", fn {handler, index} ->
+      """
+      ##{index + 1}: #{inspect(handler.to)}
+          #{Enum.map_join(handler.stacktrace, "\n    ", &Exception.format_stacktrace_entry/1)}
+      """
+    end)
+  end
+
+  def report_error(instance, {exception, stacktrace}) do
+    options = get_options(instance)
+    caller = Keyword.fetch!(options, :caller)
+
+    unless Keyword.get(options, :suppress_warning, false),
+      do: IO.warn(Exception.format(:error, exception, stacktrace))
+
+    ExUnit.OnExitHandler.add(caller, make_ref(), fn ->
+      reraise exception, stacktrace
+    end)
+
+    :ok
+  end
+
+  @impl true
+  def init(options) do
+    Process.flag(:trap_exit, true)
+
+    host_key = :public_key.generate_key({:rsa, 2048, 65_537})
+    port = Keyword.get(options, :port, 0)
+    credentials = options[:credentials]
+    instance = self()
+
+    daemon_opts = build_daemon_opts(instance, host_key, credentials)
+
+    case :ssh.daemon(port, daemon_opts) do
+      {:ok, daemon_ref} ->
+        {:ok, info} = :ssh.daemon_info(daemon_ref)
+        actual_port = :proplists.get_value(:port, info)
+
+        options =
+          options
+          |> Keyword.put(:port, actual_port)
+          |> Keyword.put(:ip, {127, 0, 0, 1})
+          |> Keyword.put(:protocol, :ssh)
+
+        {:ok,
+         %{
+           options: options,
+           host_key: host_key,
+           daemon_ref: daemon_ref,
+           handlers: %{exec: [], shell: []}
+         }}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  defp build_daemon_opts(instance, host_key, credentials) do
+    base = [
+      system_dir: String.to_charlist(System.tmp_dir!()),
+      key_cb: {TestServer.SSH.KeyAPI, [instance: instance, host_key: host_key]},
+      ssh_cli: {TestServer.SSH.Channel, [instance: instance]},
+      subsystems: [],
+      auth_methods: ~c"password,publickey"
+    ]
+
+    if credentials do
+      Keyword.put(base, :pwdfun, fn user, pass ->
+        GenServer.call(instance, {:check_password, to_string(user), to_string(pass)})
+      end)
+    else
+      base
+      |> Keyword.put(:no_auth_needed, true)
+      |> Keyword.delete(:auth_methods)
+    end
+  end
+
+  @impl true
+  def handle_call({:register, {type, options, stacktrace}}, _from, state)
+      when type in [:exec, :shell] do
+    handler = build_handler(options, stacktrace)
+    updated_handlers = state.handlers[type] ++ [handler]
+    {:reply, {:ok, handler}, put_in(state, [:handlers, type], updated_handlers)}
+  end
+
+  def handle_call({:dispatch, {type, input, chan_state}}, _from, state)
+      when type in [:exec, :shell] do
+    {result, updated_handlers} = dispatch(state.handlers[type], input, chan_state)
+    {:reply, result, put_in(state, [:handlers, type], updated_handlers)}
+  end
+
+  def handle_call({:check_password, user, pass}, _from, state) do
+    result =
+      Enum.any?(state.options[:credentials] || [], fn
+        {^user, ^pass} -> true
+        _ -> false
+      end)
+
+    {:reply, result, state}
+  end
+
+  def handle_call({:is_auth_key, user, pub_key}, _from, state) do
+    result =
+      Enum.any?(state.options[:credentials] || [], fn
+        {^user, :public_key, pem} ->
+          case :public_key.pem_decode(pem) do
+            [{_type, _der, :not_encrypted} = entry] ->
+              :public_key.pem_entry_decode(entry) == pub_key
+
+            _ ->
+              false
+          end
+
+        _ ->
+          false
+      end)
+
+    {:reply, result, state}
+  end
+
+  def handle_call(:options, _from, state) do
+    {:reply, state.options, state}
+  end
+
+  def handle_call({:handlers, type}, _from, state) when type in [:exec, :shell] do
+    {:reply, state.handlers[type], state}
+  end
+
+  @impl true
+  def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    :ssh.stop_daemon(state.daemon_ref)
+  end
+
+  defp build_handler(options, stacktrace) do
+    %{
+      ref: make_ref(),
+      match: options[:match],
+      to: Keyword.fetch!(options, :to),
+      stacktrace: stacktrace,
+      suspended: false,
+      received: []
+    }
+  end
+
+  defp dispatch(handlers, input, chan_state) do
+    handlers
+    |> Enum.find_index(fn
+      %{suspended: true} -> false
+      %{match: nil} -> true
+      %{match: match} -> try_match(match, input, chan_state)
+    end)
+    |> case do
+      nil ->
+        {{:error, :not_found}, handlers}
+
+      index ->
+        %{to: handler} = Enum.at(handlers, index)
+        result = try_handler(handler, input, chan_state)
+
+        updated_handlers =
+          List.update_at(handlers, index, fn h ->
+            %{h | suspended: true, received: h.received ++ [input]}
+          end)
+
+        {result, updated_handlers}
+    end
+  end
+
+  defp try_match(match, input, chan_state) do
+    match.(input, chan_state)
+  rescue
+    _ -> false
+  end
+
+  defp try_handler(handler, input, chan_state) do
+    case handler.(input, chan_state) do
+      {:reply, _, _} = reply ->
+        {:ok, reply}
+
+      {:ok, _} = ok ->
+        {:ok, ok}
+
+      other ->
+        {:error, {RuntimeError.exception("Invalid handler response: #{inspect(other)}"), []}}
+    end
+  rescue
+    error -> {:error, {error, __STACKTRACE__}}
+  end
+end

--- a/lib/test_server/ssh/key_api.ex
+++ b/lib/test_server/ssh/key_api.ex
@@ -1,0 +1,23 @@
+defmodule TestServer.SSH.KeyAPI do
+  @moduledoc false
+
+  @behaviour :ssh_server_key_api
+
+  @impl true
+  def host_key(algorithm, daemon_options) do
+    private = Keyword.get(daemon_options, :key_cb_private, [])
+    host_key = Keyword.fetch!(private, :host_key)
+
+    if algorithm in [:"ssh-rsa", :"rsa-sha2-256", :"rsa-sha2-512"] do
+      {:ok, host_key}
+    else
+      {:error, {:unsupported_algorithm, algorithm}}
+    end
+  end
+
+  @impl true
+  def is_auth_key(public_key, user, daemon_options) do
+    instance = daemon_options |> Keyword.get(:key_cb_private, []) |> Keyword.fetch!(:instance)
+    GenServer.call(instance, {:is_auth_key, to_string(user), public_key})
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule TestServer.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :crypto, :public_key, :inets],
+      extra_applications: [:logger, :crypto, :public_key, :inets, :ssh],
       mod: {TestServer.Application, []}
     ]
   end
@@ -88,6 +88,12 @@ defmodule TestServer.MixProject do
           TestServer.HTTP.Server.Httpd,
           TestServer.HTTP.Server.Bandit,
           TestServer.HTTP.Server.Plug.Cowboy
+        ],
+        SSH: [
+          TestServer.SSH,
+          TestServer.SSH.Instance,
+          TestServer.SSH.KeyAPI,
+          TestServer.SSH.Channel
         ]
       ]
     ]

--- a/test/examples/ssh_usage_test.exs
+++ b/test/examples/ssh_usage_test.exs
@@ -1,0 +1,81 @@
+defmodule MyApp.SSH do
+  @moduledoc false
+
+  # A minimal SSH client — the kind of module a library consumer would write
+  # and want to test against TestServer.SSH.
+  def run(host, port, command, opts \\ []) do
+    user = Keyword.get(opts, :user, "deploy")
+    password = Keyword.get(opts, :password)
+
+    connect_opts =
+      [
+        user: String.to_charlist(user),
+        silently_accept_hosts: true,
+        user_interaction: false,
+        save_accepted_host: false
+      ]
+      |> then(fn o ->
+        if password, do: Keyword.put(o, :password, String.to_charlist(password)), else: o
+      end)
+
+    with {:ok, conn} <- :ssh.connect(String.to_charlist(host), port, connect_opts) do
+      {:ok, ch} = :ssh_connection.session_channel(conn, :infinity)
+      :success = :ssh_connection.exec(conn, ch, String.to_charlist(command), :infinity)
+      result = collect(ch, {0, "", ""})
+      :ssh.close(conn)
+      result
+    end
+  end
+
+  defp collect(ch, {code, out, err}) do
+    receive do
+      {:ssh_cm, _, {:data, ^ch, 0, data}} -> collect(ch, {code, out <> data, err})
+      {:ssh_cm, _, {:data, ^ch, 1, data}} -> collect(ch, {code, out, err <> data})
+      {:ssh_cm, _, {:exit_status, ^ch, c}} -> collect(ch, {c, out, err})
+      {:ssh_cm, _, {:closed, ^ch}} -> {:ok, code, out, err}
+    after
+      5_000 -> {:error, :timeout}
+    end
+  end
+end
+
+defmodule MyApp.SSHUsageTest do
+  use ExUnit.Case
+
+  # Demonstrates the intended public API of TestServer.SSH from a consumer's perspective.
+
+  test "runs a remote command and returns output" do
+    TestServer.SSH.exec(to: fn "deploy", state -> {:reply, {0, "deployed v1.0\n", ""}, state} end)
+    {host, port} = TestServer.SSH.address()
+    assert {:ok, 0, "deployed v1.0\n", ""} = MyApp.SSH.run(host, port, "deploy")
+  end
+
+  test "propagates non-zero exit codes" do
+    TestServer.SSH.exec(to: fn _, state -> {:reply, {1, "", "permission denied\n"}, state} end)
+    {host, port} = TestServer.SSH.address()
+    assert {:ok, 1, "", "permission denied\n"} = MyApp.SSH.run(host, port, "restricted")
+  end
+
+  test "sequential deploys consume handlers in FIFO order" do
+    TestServer.SSH.exec(to: fn _, state -> {:reply, {0, "deploy 1\n", ""}, state} end)
+    TestServer.SSH.exec(to: fn _, state -> {:reply, {0, "deploy 2\n", ""}, state} end)
+    {host, port} = TestServer.SSH.address()
+    assert {:ok, 0, "deploy 1\n", ""} = MyApp.SSH.run(host, port, "deploy")
+    assert {:ok, 0, "deploy 2\n", ""} = MyApp.SSH.run(host, port, "deploy")
+  end
+
+  test "accepts client with correct password" do
+    {:ok, instance} = TestServer.SSH.start(credentials: [{"deploy", "hunter2"}])
+    TestServer.SSH.exec(instance, to: fn _, state -> {:reply, {0, "ok\n", ""}, state} end)
+    {host, port} = TestServer.SSH.address(instance)
+
+    assert {:ok, 0, "ok\n", ""} =
+             MyApp.SSH.run(host, port, "deploy", user: "deploy", password: "hunter2")
+  end
+
+  test "rejects client with wrong password" do
+    {:ok, _instance} = TestServer.SSH.start(credentials: [{"deploy", "hunter2"}])
+    {host, port} = TestServer.SSH.address()
+    assert {:error, _} = MyApp.SSH.run(host, port, "anything", user: "deploy", password: "wrong")
+  end
+end

--- a/test/support/ssh_client.ex
+++ b/test/support/ssh_client.ex
@@ -1,0 +1,48 @@
+defmodule TestServer.SSHClient do
+  @moduledoc false
+
+  def connect(host, port, opts \\ []) do
+    defaults = [
+      user_interaction: false,
+      silently_accept_hosts: true,
+      save_accepted_host: false
+    ]
+
+    :ssh.connect(String.to_charlist(host), port, Keyword.merge(defaults, opts))
+  end
+
+  def exec(conn, command) do
+    {:ok, ch} = :ssh_connection.session_channel(conn, :infinity)
+    :success = :ssh_connection.exec(conn, ch, String.to_charlist(command), :infinity)
+    collect_exec(ch, {0, "", ""})
+  end
+
+  def open_shell(conn) do
+    {:ok, ch} = :ssh_connection.session_channel(conn, :infinity)
+    :ok = :ssh_connection.shell(conn, ch)
+    ch
+  end
+
+  def send(conn, ch, data) do
+    :ssh_connection.send(conn, ch, data)
+  end
+
+  def recv(ch, timeout \\ 5_000) do
+    receive do
+      {:ssh_cm, _, {:data, ^ch, 0, data}} -> {:ok, data}
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp collect_exec(ch, {code, out, err}) do
+    receive do
+      {:ssh_cm, _, {:data, ^ch, 0, data}} -> collect_exec(ch, {code, out <> data, err})
+      {:ssh_cm, _, {:data, ^ch, 1, data}} -> collect_exec(ch, {code, out, err <> data})
+      {:ssh_cm, _, {:exit_status, ^ch, c}} -> collect_exec(ch, {c, out, err})
+      {:ssh_cm, _, {:closed, ^ch}} -> {code, out, err}
+    after
+      5_000 -> {:error, :timeout}
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,8 @@
 ExUnit.start()
 
+# Suppress verbose SSH application logs (debug KEX ordering, notice disconnect messages)
+Logger.configure(level: :warning)
+
 http_server = System.get_env("HTTP_SERVER", "Bandit")
 
 # This ensures that `Bandit.Clock` has started and prevents

--- a/test/test_server/ssh_test.exs
+++ b/test/test_server/ssh_test.exs
@@ -1,0 +1,359 @@
+defmodule TestServer.SSHTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias TestServer.SSHClient
+
+  describe "start/1" do
+    test "auto-assigns port" do
+      {:ok, instance} = TestServer.SSH.start()
+      {_host, port} = TestServer.SSH.address(instance)
+      assert is_integer(port) and port > 0
+    end
+
+    test "multiple independent instances have different ports" do
+      {:ok, instance_1} = TestServer.SSH.start()
+      {:ok, instance_2} = TestServer.SSH.start()
+      {_, port1} = TestServer.SSH.address(instance_1)
+      {_, port2} = TestServer.SSH.address(instance_2)
+      refute port1 == port2
+    end
+  end
+
+  describe "exec/1" do
+    test "default handler returns exit 0 with empty output" do
+      TestServer.SSH.exec([])
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      assert SSHClient.exec(conn, "anything") == {0, "", ""}
+      :ssh.close(conn)
+    end
+
+    test "to: function receives command and returns output" do
+      TestServer.SSH.exec(to: fn cmd, state -> {:reply, {0, "got: #{cmd}", ""}, state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      assert SSHClient.exec(conn, "ls") == {0, "got: ls", ""}
+      :ssh.close(conn)
+    end
+
+    test "returns exit code and stderr" do
+      TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {1, "", "error\n"}, state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      assert SSHClient.exec(conn, "fail") == {1, "", "error\n"}
+      :ssh.close(conn)
+    end
+
+    test "match: filters which handler runs" do
+      TestServer.SSH.exec(
+        match: fn cmd, _state -> cmd == "ls" end,
+        to: fn _cmd, state -> {:reply, {0, "matched\n", ""}, state} end
+      )
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      assert SSHClient.exec(conn, "ls") == {0, "matched\n", ""}
+      :ssh.close(conn)
+    end
+
+    test "FIFO consumption order" do
+      TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {0, "first\n", ""}, state} end)
+      TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {0, "second\n", ""}, state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      assert SSHClient.exec(conn, "cmd") == {0, "first\n", ""}
+      assert SSHClient.exec(conn, "cmd") == {0, "second\n", ""}
+      :ssh.close(conn)
+    end
+
+    test "unmatched request reports error at test exit" do
+      defmodule UnmatchedExecTest do
+        use ExUnit.Case
+
+        test "fails" do
+          TestServer.SSH.exec(
+            match: fn cmd, _state -> cmd == "ls" end,
+            to: fn _cmd, state -> {:reply, {0, "ok", ""}, state} end
+          )
+
+          {host, port} = TestServer.SSH.address()
+          {:ok, conn} = TestServer.SSHClient.connect(host, port, user: ~c"test")
+          TestServer.SSHClient.exec(conn, "not-ls")
+          :ssh.close(conn)
+        end
+      end
+
+      log =
+        capture_io(:stderr, fn ->
+          capture_io(fn -> ExUnit.run() end)
+        end)
+
+      assert log =~ "received an unexpected SSH exec request"
+    end
+
+    test "{:ok, state} return exits with code 0 and no output" do
+      TestServer.SSH.exec(to: fn _cmd, state -> {:ok, state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      assert SSHClient.exec(conn, "noop") == {0, "", ""}
+      :ssh.close(conn)
+    end
+
+    test "unconsumed handler raises at test exit" do
+      defmodule UnconsumedExecTest do
+        use ExUnit.Case
+
+        test "fails" do
+          TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {0, "ok", ""}, state} end)
+        end
+      end
+
+      assert capture_io(fn -> ExUnit.run() end) =~ "did not receive exec requests"
+    end
+  end
+
+  describe "shell/1" do
+    test "echoes data by default" do
+      TestServer.SSH.shell([])
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      ch = SSHClient.open_shell(conn)
+      SSHClient.send(conn, ch, "hello\n")
+      assert SSHClient.recv(ch) == {:ok, "hello\n"}
+      :ssh.close(conn)
+    end
+
+    test "to: function receives data and returns reply" do
+      TestServer.SSH.shell(to: fn _data, state -> {:reply, "pong\n", state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      ch = SSHClient.open_shell(conn)
+      SSHClient.send(conn, ch, "ping\n")
+      assert SSHClient.recv(ch) == {:ok, "pong\n"}
+      :ssh.close(conn)
+    end
+
+    test "match: filters which handler runs" do
+      TestServer.SSH.shell(
+        match: fn data, _state -> data == "ping\n" end,
+        to: fn _data, state -> {:reply, "pong\n", state} end
+      )
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      ch = SSHClient.open_shell(conn)
+      SSHClient.send(conn, ch, "ping\n")
+      assert SSHClient.recv(ch) == {:ok, "pong\n"}
+      :ssh.close(conn)
+    end
+
+    test "FIFO consumption with multi-turn conversation" do
+      TestServer.SSH.shell(to: fn _data, state -> {:reply, "first\n", state} end)
+      TestServer.SSH.shell(to: fn _data, state -> {:reply, "second\n", state} end)
+      TestServer.SSH.shell(to: fn _data, state -> {:reply, "third\n", state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+      ch = SSHClient.open_shell(conn)
+
+      SSHClient.send(conn, ch, "msg1\n")
+      assert SSHClient.recv(ch) == {:ok, "first\n"}
+
+      SSHClient.send(conn, ch, "msg2\n")
+      assert SSHClient.recv(ch) == {:ok, "second\n"}
+
+      SSHClient.send(conn, ch, "msg3\n")
+      assert SSHClient.recv(ch) == {:ok, "third\n"}
+
+      :ssh.close(conn)
+    end
+
+    test "unexpected shell data reports error at test exit" do
+      defmodule UnmatchedShellTest do
+        use ExUnit.Case
+
+        test "fails" do
+          TestServer.SSH.shell(
+            match: fn data, _state -> data == "expected\n" end,
+            to: fn _data, state -> {:reply, "ok\n", state} end
+          )
+
+          {host, port} = TestServer.SSH.address()
+          {:ok, conn} = TestServer.SSHClient.connect(host, port, user: ~c"test")
+          ch = TestServer.SSHClient.open_shell(conn)
+          TestServer.SSHClient.send(conn, ch, "unexpected\n")
+          Process.sleep(100)
+          :ssh.close(conn)
+        end
+      end
+
+      log =
+        capture_io(:stderr, fn ->
+          capture_io(fn -> ExUnit.run() end)
+        end)
+
+      assert log =~ "received unexpected SSH shell data"
+    end
+
+    test "unconsumed shell handler raises at test exit" do
+      defmodule UnconsumedShellTest do
+        use ExUnit.Case
+
+        test "fails" do
+          TestServer.SSH.shell(to: fn _data, state -> {:reply, "ok\n", state} end)
+        end
+      end
+
+      assert capture_io(fn -> ExUnit.run() end) =~ "did not receive shell requests"
+    end
+  end
+
+  describe "mixed exec and shell" do
+    test "exec and shell on same instance" do
+      TestServer.SSH.exec(to: fn _cmd, state -> {:reply, {0, "exec-ok\n", ""}, state} end)
+      TestServer.SSH.shell(to: fn _data, state -> {:reply, "shell-ok\n", state} end)
+
+      {host, port} = TestServer.SSH.address()
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"test")
+
+      assert SSHClient.exec(conn, "cmd") == {0, "exec-ok\n", ""}
+
+      ch = SSHClient.open_shell(conn)
+      SSHClient.send(conn, ch, "hello\n")
+      assert SSHClient.recv(ch) == {:ok, "shell-ok\n"}
+
+      :ssh.close(conn)
+    end
+  end
+
+  describe "credentials - no auth" do
+    test "accepts any user without credentials option" do
+      {:ok, instance} = TestServer.SSH.start()
+      TestServer.SSH.exec(instance, to: fn _cmd, state -> {:reply, {0, "ok", ""}, state} end)
+
+      {host, port} = TestServer.SSH.address(instance)
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"anyone")
+      assert SSHClient.exec(conn, "cmd") == {0, "ok", ""}
+      :ssh.close(conn)
+    end
+  end
+
+  describe "credentials - password auth" do
+    test "accepts valid password" do
+      {:ok, instance} = TestServer.SSH.start(credentials: [{"alice", "secret"}])
+      TestServer.SSH.exec(instance, to: fn _cmd, state -> {:reply, {0, "ok", ""}, state} end)
+
+      {host, port} = TestServer.SSH.address(instance)
+      {:ok, conn} = SSHClient.connect(host, port, user: ~c"alice", password: ~c"secret")
+      assert SSHClient.exec(conn, "cmd") == {0, "ok", ""}
+      :ssh.close(conn)
+    end
+
+    test "rejects invalid password" do
+      {:ok, _instance} = TestServer.SSH.start(credentials: [{"alice", "secret"}])
+      {host, port} = TestServer.SSH.address()
+      assert {:error, _} = SSHClient.connect(host, port, user: ~c"alice", password: ~c"wrong")
+    end
+
+    test "rejects unknown user" do
+      {:ok, _instance} = TestServer.SSH.start(credentials: [{"alice", "secret"}])
+      {host, port} = TestServer.SSH.address()
+      assert {:error, _} = SSHClient.connect(host, port, user: ~c"bob", password: ~c"secret")
+    end
+  end
+
+  describe "credentials - public key auth" do
+    setup do
+      private_key = :public_key.generate_key({:rsa, 2048, 65_537})
+      {:RSAPrivateKey, _, modulus, public_exp, _, _, _, _, _, _, _} = private_key
+      public_key = {:RSAPublicKey, modulus, public_exp}
+
+      public_pem =
+        :public_key.pem_encode([:public_key.pem_entry_encode(:RSAPublicKey, public_key)])
+
+      user_dir = Path.join(System.tmp_dir!(), "ssh_test_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(user_dir)
+
+      private_pem =
+        :public_key.pem_encode([:public_key.pem_entry_encode(:RSAPrivateKey, private_key)])
+
+      id_rsa_path = Path.join(user_dir, "id_rsa")
+      File.write!(id_rsa_path, private_pem)
+      File.chmod!(id_rsa_path, 0o600)
+
+      on_exit(fn -> File.rm_rf!(user_dir) end)
+
+      {:ok, public_pem: public_pem, user_dir: user_dir}
+    end
+
+    test "accepts valid public key", %{public_pem: public_pem, user_dir: user_dir} do
+      {:ok, instance} =
+        TestServer.SSH.start(credentials: [{"bob", :public_key, public_pem}])
+
+      TestServer.SSH.exec(instance, to: fn _cmd, state -> {:reply, {0, "ok", ""}, state} end)
+
+      {host, port} = TestServer.SSH.address(instance)
+
+      {:ok, conn} =
+        SSHClient.connect(host, port,
+          user: ~c"bob",
+          user_dir: String.to_charlist(user_dir),
+          auth_methods: ~c"publickey"
+        )
+
+      assert SSHClient.exec(conn, "cmd") == {0, "ok", ""}
+      :ssh.close(conn)
+    end
+
+    test "rejects unknown public key", %{user_dir: user_dir} do
+      other_key = :public_key.generate_key({:rsa, 2048, 65_537})
+      {:RSAPrivateKey, _, modulus, public_exp, _, _, _, _, _, _, _} = other_key
+      other_public_key = {:RSAPublicKey, modulus, public_exp}
+
+      other_public_pem =
+        :public_key.pem_encode([:public_key.pem_entry_encode(:RSAPublicKey, other_public_key)])
+
+      {:ok, _instance} =
+        TestServer.SSH.start(credentials: [{"bob", :public_key, other_public_pem}])
+
+      {host, port} = TestServer.SSH.address()
+
+      assert {:error, _} =
+               SSHClient.connect(host, port,
+                 user: ~c"bob",
+                 user_dir: String.to_charlist(user_dir),
+                 auth_methods: ~c"publickey"
+               )
+    end
+  end
+
+  describe "multi-instance" do
+    test "error when multiple instances and no explicit instance arg" do
+      {:ok, _instance_1} = TestServer.SSH.start()
+      {:ok, _instance_2} = TestServer.SSH.start()
+
+      assert_raise RuntimeError, ~r/Multiple.*running.*pass instance/, fn ->
+        TestServer.SSH.address()
+      end
+    end
+
+    test "explicit instance arg works with multiple instances" do
+      {:ok, instance_1} = TestServer.SSH.start()
+      {:ok, instance_2} = TestServer.SSH.start()
+
+      {_, port1} = TestServer.SSH.address(instance_1)
+      {_, port2} = TestServer.SSH.address(instance_2)
+
+      refute port1 == port2
+    end
+  end
+end


### PR DESCRIPTION
The goal of TestServer is to support any network protocol under a single, consistent testing API, with shared lifecycle management and ExUnit integration. Right now adding a new protocol is constrained because InstanceManager has HTTP-specific assumptions baked in — it hardcodes HTTP instance construction and teardown, making it impossible to reuse for other protocols.

The natural evolution is to move protocol-specific logic into submodules (TestServer.PROTOCOL) while keeping InstanceManager and InstanceSupervisor as shared, protocol-agnostic infrastructure.

This PR introduces TestServer.SSH as the first protocol under this model. HTTP/WebSocket will be refactored to match in a follow-up once the pattern is validated.