### PR TITLE
Remove dead handle_call from InstanceManager

### DIFF
--- a/lib/test_server/instance_manager.ex
+++ b/lib/test_server/instance_manager.ex
@@ -59,12 +59,6 @@ defmodule TestServer.InstanceManager do
     {:reply, instance, state}
   end
 
-  def handle_call({:alive?, instance}, _from, state) do
-    instance = Enum.find(state.instances, &(&1.instance == instance))
-
-    {:reply, not is_nil(instance)}
-  end
-
   def handle_call({:remove, instance}, _from, state) do
     state = %{state | instances: Enum.reject(state.instances, &(&1.instance == instance))}
 


### PR DESCRIPTION
handle_call/3 with {:alive?, instance} is never used and is dead code. You can also see the response is incorrect