### PR TITLE
Call protocol module stop to terminate instance

### DIFF
--- a/lib/test_server.ex
+++ b/lib/test_server.ex
@@ -48,7 +48,7 @@ defmodule TestServer do
 
     case InstanceManager.start_instance(caller, protocol_module, options) do
       {:ok, instance} ->
-        put_ex_unit_on_exit_callback(instance, verify_fn)
+        put_ex_unit_on_exit_callback(protocol_module, instance, verify_fn)
         {:ok, instance}
 
       {:error, error} ->
@@ -56,11 +56,14 @@ defmodule TestServer do
     end
   end
 
-  defp put_ex_unit_on_exit_callback(instance, verify_fn) do
+  defp put_ex_unit_on_exit_callback(protocol_module, instance, verify_fn) do
     ExUnit.Callbacks.on_exit(fn ->
       if Process.alive?(instance) do
-        verify_fn.(instance)
-        InstanceManager.stop_instance(instance)
+        try do
+          verify_fn.(instance)
+        after
+          protocol_module.stop(instance)
+        end
       end
     end)
   end

--- a/test/test_server/http_test.exs
+++ b/test/test_server/http_test.exs
@@ -105,6 +105,18 @@ defmodule TestServer.HTTPTest do
         TestServer.HTTP.start(http_server: :invalid)
       end
     end
+
+    test "when test stop" do
+      port = TestServer.open_port([])
+
+      on_exit(fn ->
+        refute :gen_tcp.listen(port, []) == {:error, :eaddrinuse},
+               "Port #{port} must be released after test ends"
+      end)
+
+      assert {:ok, _instance} = TestServer.HTTP.start(port: port)
+      assert {:error, :eaddrinuse} = :gen_tcp.listen(port, [])
+    end
   end
 
   describe "stop/1" do

--- a/test/test_server/ssh_test.exs
+++ b/test/test_server/ssh_test.exs
@@ -302,6 +302,18 @@ defmodule TestServer.SSHTest do
                assert {:ok, _conn} = SSHClient.connect(TestServer.SSH.address())
              end) =~ "server will use strict KEX ordering"
     end
+
+    test "when test stop" do
+      port = TestServer.open_port([])
+
+      on_exit(fn ->
+        refute :gen_tcp.listen(port, []) == {:error, :eaddrinuse},
+               "Port #{port} must be released after test ends"
+      end)
+
+      assert {:ok, _instance} = TestServer.SSH.start(port: port)
+      assert {:error, :eaddrinuse} = :gen_tcp.listen(port, [])
+    end
   end
 
   defp write_user_dir_pem!(context, key) do


### PR DESCRIPTION
#52 introduced a bug where the full instance is not terminated. This adds both tests and do proper module callback.